### PR TITLE
Update rsl-rl-lib version constraint to fix ValueError when start training.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     install_requires=[
         # 'isaacsim',
         "IsaacLab",
-        "rsl-rl-lib>=2.3.0",
+        "rsl-rl-lib>=2.3.0,<3.0.0",
     ],
 )


### PR DESCRIPTION
开始训练时报错：
```
Traceback (most recent call last):
  File "/home/c112/codes/LeggedLab/legged_lab/scripts/train.py", line 101, in <module>
    train()
  File "/home/c112/codes/LeggedLab/legged_lab/scripts/train.py", line 85, in train
    runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/c112/miniconda3/envs/LeggedLab/lib/python3.11/site-packages/rsl_rl/runners/on_policy_runner.py", line 45, in __init__
    self.cfg["obs_groups"] = resolve_obs_groups(obs, self.cfg["obs_groups"], default_sets)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/c112/miniconda3/envs/LeggedLab/lib/python3.11/site-packages/rsl_rl/utils/utils.py", line 252, in resolve_obs_groups
    raise ValueError(
ValueError: The observation configuration dictionary 'obs_groups' must contain the 'policy' key. Found keys: []
```
后尝试使用低于`3.0`版本的`rsl_rl`包测试发现没有报错，应该是`rsl_rl`包的版本问题，于是修改了`setup.py`中`install_requires`里对`rsl-rl-lib`的版本要求，添加了`<3.0.0`。

目前不确定较早的`3.0`版本的`rsl_rl`包是否报错，但是`2.0`版本中最新的`2.3.3`是没问题的。
